### PR TITLE
Migrate storefront architecture content

### DIFF
--- a/src/pages/guides/storefront-architecture/build-time/index.md
+++ b/src/pages/guides/storefront-architecture/build-time/index.md
@@ -3,3 +3,132 @@ title: Build time architecture
 ---
 
 # Build time architecture
+
+The build architecture of PWA Studio is the system used to compile JavaScript and CSS source code into a production-ready PWA storefront application.
+
+## Magento store dependency
+
+PWA Studio is part of Magento's [service-oriented architecture][] vision.
+This vision minimizes dependencies by separating the merchant-facing store admin and the shopper-facing storefront application.
+Separating these two applications minimizes the dependencies between them.
+
+[service-oriented architecture]: https://en.wikipedia.org/wiki/Service-oriented_architecture
+
+The Venia build system respects this principle by running the build process independent from the Magento core application.
+However, the build system does use the Magento API at compilation time for additional validation and optimization of storefront code.
+
+## Repository organization
+
+Unlike Magento themes, the source code for a PWA Studio storefront does not need to be located within the Magento application code.
+A PWA Studio storefront and its backing Magento server are two separate applications, so
+their codebase is separate from each other.
+
+The Venia concept storefront uses the `yarn` package for dependency management, but
+storefronts built using PWA Studio can also use NPM to manage dependencies and run scripts.
+
+Early adopters of PWA Studio have cloned the [`pwa-studio` repository][] and made direct customizations to the Venia concept source.
+This can lead to conflicts when updating to the latest version of the codebase.
+The preferred approach is to add PWA Studio tools and libraries as dependencies in a project.
+
+[`pwa-studio` repository]: https://github.com/magento/pwa-studio/
+
+The recommended way of getting started is to use the scaffolding tool to [setup a new storefront project][].
+
+[setup a new storefront project]: /tutorials/setup-storefront/
+
+## Build pipeline
+
+The build pipeline is the mechanism that consumes the project source code to generate production-ready files.
+This process includes code [transpilation][] and smart script bundling.
+Like most modern Web compilation tools, it is built on [NodeJS][].
+
+[transpilation]: https://en.wikipedia.org/wiki/Source-to-source_compiler
+[nodejs]: https://nodejs.org/en/about/
+
+The main tools used for the build pipeline are [Babel][] and [Webpack][].
+The Buildpack library provides a convenient API for configuring these tools, but the underlying API for building a Magento PWA is a direct configuration of Babel and Webpack.
+
+[babel]: https://babeljs.io
+[webpack]: https://webpack.js.org/
+
+The Venia example storefront project contains an opinionated build pipeline setup, using Buildpack's `configureWebpack` API, but
+developers can also use the PWA-Studio build libraries and configurations to define custom pipelines.
+
+### Venia build steps
+
+The following sections provide insight into the processes that make up Venia's build pipeline.
+
+#### Starting a build
+
+Venia's build process begins at the command prompt.
+It is compatible with OSX and most Linux environments that use a `bash` shell.
+
+PWA Studio projects use [NPM scripts][] to organize frequently used commands.
+These `yarn run` commands are found in the `scripts` section of the Venia storefront's [package.json][] file.
+
+[npm scripts]: https://docs.npmjs.com/misc/scripts
+[package.json]: https://github.com/magento/pwa-studio/blob/develop/packages/venia-concept/package.json
+
+Use the `build` command to start the build process:
+
+```sh
+yarn run build
+```
+
+#### Cleanup step
+
+The build process runs a `clean` script to remove old artifacts from the Venia concept's `dist` directory before generating the code.
+
+#### Environment validation
+
+The next phase uses the `buildpack load-env` command to load and validate the `.env` file, which describes the store project configuration.
+This file is found in the root directory of the Venia concept project.
+
+See [Configuration management][] for more information.
+
+[configuration management]: /guides/general-concepts/configuration/
+
+<InlineAlert variant="info" slots="text"/>
+
+If there is no `.env` file in your project, create one with the [`buildpack create-env-file` command][].
+
+[`buildpack create-env-file` command]: /api/buildpack/cli/create-environment-file/
+
+#### Query validation
+
+After the environment validation phase, the build runs the `validate-queries` script.
+This script uses the [`graphql-cli-validate-magento-pwa-queries`][] tool to analyze the GraphQL queries in the project and validates them against the schema downloaded from the configured Magento instance.
+
+[`graphql-cli-validate-magento-pwa-queries`]: https://github.com/magento/pwa-studio/tree/develop/packages/graphql-cli-validate-magento-pwa-queries
+
+<InlineAlert variant="info" slots="text"/>
+
+The connected Magento instance is defined by the `MAGENTO_BACKEND_URL` environment variable.
+
+#### Webpack execution
+
+The final step in the build process uses the webpack CLI (`webpack`) to process files into bundles.
+The `webpack.config.js` file in the storefront project's root configures webpack to use external tools, such as Babel and Workbox, during file processing and bundle creation.
+
+The artifacts generated by webpack are located in the `dist` folder.
+These are static files ready to be served from an HTML document's app shell.
+
+When a browser loads these files, it launches a single-page application that is the Venia storefront.
+
+### Other build features
+
+The following build features are used mainly in a development environment.
+They are not part of the normal production build process.
+
+#### Watch mode
+
+The `watch` script launches a development server and a persistent compiler process that monitors the source code for changes.
+When a change is detected, it initiates an incremental rebuild instead of a full build to keep the application in the browser up to date.
+
+This feature allows you to make edits in the code and see the changes in the application without going through the full build process.
+
+#### Linting and testing
+
+The Venia concept project also contains scripts for formatting (`yarn run prettier`), style analysis (`yarn run lint`), and running unit tests (`yarn test`).
+
+Use these scripts to keep your codebase well-formatted and test functionality.

--- a/src/pages/guides/storefront-architecture/index.md
+++ b/src/pages/guides/storefront-architecture/index.md
@@ -3,3 +3,35 @@ title: Storefront architecture
 ---
 
 # Storefront architecture
+
+Unlike a Magento theme, which is dependent on the core Magento application, a PWA Studio storefront exists on a different application layer from Magento.
+The storefront still communicates with the core Magento application, but it is not tightly coupled with it.
+
+## Headless architecture overview
+
+Headless architecture refers to the idea of separating the presentation layer from the data and business logic layer.
+Decoupling these two layers give merchants the ability to make changes to the frontend without modifying code for the backend services.
+
+In the context of PWA Studio, the storefront is the frontend application and Magento is the connected backend service.
+A PWA Studio storefront does not use any of Magento's frontend theme assets, layout files, or scripts.
+Instead, it defines its own frontend files and uses Magento's GraphQL and REST services to send or request data.
+
+For more information about headless eCommerce, read the Magento blog post titled [The Future Is Headless][].
+
+[the future is headless]: https://magento.com/blog/best-practices/future-headless
+
+## Magento microservices
+
+Microservice architecture is a design pattern that separates an application into independent, deployable services.
+Each independent service communicates with the others through lightweight APIs.
+This is known as **service isolation**.
+
+Magento services, such as those for customers, product catalog, and checkout, provide an API through [service contracts][].
+PWA Studio storefronts interact with these services through [Magento's GraphQL][] and REST services.
+
+[service contracts]: https://devdocs.magento.com/guides/v2.3/extension-dev-guide/service-contracts/service-contracts.html
+[magento's graphql]: https://github.com/magento/graphql-ce
+
+For more information about Magento's research on service isolation, see [Magento Service Isolation Vision][].
+
+[magento service isolation vision]: https://github.com/magento/architecture/blob/master/design-documents/service-isolation.md

--- a/src/pages/guides/storefront-architecture/run-time/index.md
+++ b/src/pages/guides/storefront-architecture/run-time/index.md
@@ -3,3 +3,56 @@ title: Run time architecture
 ---
 
 # Run time architecture
+
+A PWA Studio storefront's runtime architecture describes how each of its pieces interact with Magento when it is deployed.
+The following sections describe characteristics for the runtime architecture of storefronts built using PWA Studio.
+Many of these characteristics follow Magento's vision for [service isolation][].
+
+[service isolation]: https://github.com/magento/architecture/blob/master/design-documents/service-isolation.md
+
+## API-only relationships
+
+A PWA Studio storefront application communicates with Magento using its external API.
+Those external API services communicate with Magento's internal service modules and returns any results through that same external API.
+
+**GraphQL** is the preferred API to use for client data and store behavior.
+[GraphQL API][] coverage increases with every Magento release, but
+until full coverage is complete, developers can use the [**REST API**][] to fill in existing coverage gaps.
+
+[graphql api]: https://devdocs.magento.com/guides/v2.3/graphql/
+[**rest api**]: https://devdocs.magento.com/guides/v2.3/rest/bk-rest.html
+
+To make secure, admin-authorized calls, configure the storefront's [UPWARD][] server to make the request using REST or RPC.
+
+[upward]: /guides/packages/upward/
+
+Use **HTTPS** when passing requests through the UPWARD server to static and media resources in Magento.
+
+## One-way coupling
+
+The coupling between a PWA Studio storefront and Magento should go in one direction.
+The storefront has a dependency on Magento, which is attached as a service, but
+the Magento application should not have a dependency on the storefront.
+
+## Decoupled deployments
+
+A PWA Studio storefront and its backing Magento instance should be deployed as separate instances on separate hardware.
+Using [UPWARD][] allows you to deploy these applications using different technology stacks with the dependency configured at build-time.
+
+Another option is to deploy the storefront to the Magento server directly using the [PHP implementation of UPWARD][].
+This is a possible option if the Magento instance is hosted in the [Magento cloud][].
+
+[php implementation of upward]: https://github.com/magento/upward-php
+[magento cloud]: /tutorials/production-deployment/magento-cloud/
+
+## Storefront replacement mechanism
+
+A PWA Studio storefront replaces Magento's frontend theme.
+
+Since the coupling between the storefront and Magento is one way, Magento does not know to direct front end traffic to the storefront application.
+This means that the Magento frontend theme, such as Luma, is still available by connecting directly to the Magento server.
+
+Use a [reverse proxy][] in your Magento server to route incoming frontend traffic to the storefront application.
+If the storefront application is deployed in the same server as Magento, which can be the case if you are using [Magento cloud][] hosting, then the `magento-upward-connector` module handles the frontend replacement.
+
+[reverse proxy]: https://en.wikipedia.org/wiki/Reverse_proxy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Migrate content for the **Guides > Storefront architecture** section of the site.

## Related Issue

Closes PWA-1625

## Motivation and Context

Content migration

## How Has This Been Tested?

1. Ran the linter: `npm run lint`
1. Verify only 1 warning (unrelated to this PR)
2. Ran the prettier check: `npm run prettier:test`
3. Verify no prettier errors
4. Search for starting liquid tag text in directory (`{%`)
5. Verify no search results found

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

