### PR TITLE
Removing TOC entry for now

### DIFF
--- a/src/data/navigation/sections/metapackages.js
+++ b/src/data/navigation/sections/metapackages.js
@@ -13,10 +13,6 @@ module.exports = [
         path: "/metapackages/open-source/",
       },
       {
-        title: "Install Commerce metapackage",
-        path: "/metapackages/commerce/",
-      },
-      {
         title: "Install Venia sample data metapackage",
         path: "/metapackages/venia-sample-data/",
       },

--- a/src/pages/metapackages/index.md
+++ b/src/pages/metapackages/index.md
@@ -9,7 +9,6 @@ With the introduction of metapackages in PWA Studio 12.1.0 and 12.2.0, you can u
 Available metapackages:
 
 -  Open Source metapackage
--  Commerce metapackage
 -  Venia Sample Data metapackage
 
 ## Open Source metapackage (Required for all projects)
@@ -18,12 +17,6 @@ PWA Studio release 12.1.0 or higher requires the Open Source metapackage to be i
 
 See [Install Open Source metapackage][] for instructions.
 
-## Adobe Commerce metapackage (Required for Commerce projects)
-
-In addition to the Open Source metapackage, you must also install the Adobe Commerce metapackage if you are using Adobe Commerce as your backend.
-
-See [Install Commerce metapackage][] for instructions.
-
 ## Venia Sample Data metapackage (Optional)
 
 You can use this metapackage to install Venia sample data into your projects.
@@ -31,5 +24,4 @@ You can use this metapackage to install Venia sample data into your projects.
 See [Install Venia Sample Data metapackage][] for instructions.
 
 [Install Open Source metapackage]: open-source/index.md
-[Install Commerce metapackage]: commerce/index.md
 [Install Venia Sample Data metapackage]: venia-sample-data/index.md

--- a/src/pages/metapackages/index.md
+++ b/src/pages/metapackages/index.md
@@ -4,7 +4,7 @@ title: Metapackages
 
 # Metapackages
 
-With the introduction of metapackages in PWA Studio 12.1.0 and 12.2.0, you can use them to add new features and sample data to your Open Source or Commerce backends. For example, in release 12.1.0, we used the [Open Source metapackage][] to extend the GraphQL schema to include a new mutation and a new field to provide more details for cart item errors. You can use these packages to add similar backend functionality to your projects.
+With PWA Studio 12.1.0, you can now use metapackages to extend Magento Open Source backends with new features and sample data. As an example, in release 12.1.0 we used the [Open Source metapackage][] to extend the GraphQL schema with a new mutation and a new field providing more information about cart item errors. These packages can be used to add similar backend functionality to your projects.
 
 Available metapackages:
 

--- a/src/pages/metapackages/open-source/index.md
+++ b/src/pages/metapackages/open-source/index.md
@@ -6,10 +6,6 @@ title: Install the Open Source metapackage
 
 You must install this metapackage in all projects using PWA Studio 12.1.0 and higher.
 
-## Prerequisite
-
--  Magento Open Source or Adobe Commerce installation.
-
 ## Installation as a git-based composer package
 
 To set up and develop your PWA extension modules locally, use the following instructions.
@@ -17,7 +13,7 @@ To set up and develop your PWA extension modules locally, use the following inst
 1. Clone the `magento2-pwa` repository into your vendor directory name:
 
     ```bash
-    git clone git@github.com:magento-commerce/magento2-pwa.git ext/magento/magento2-pwa
+    git clone git@github.com:magento/magento2-pwa.git ext/magento/magento2-pwa
     ```
 
 1. Update the `magento2/composer.json` settings to create a better development workflow for your extension modules:


### PR DESCRIPTION
## Description

This PR removes a TOC entry for the Adobe Commerce PWA metapackage.
It will be restored when the package is released.

## Related Issue

https://jira.corp.magento.com/browse/PWA-2556

## Motivation and Context

Instructions are causing user errors.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
