### PR TITLE
Fixed broken link and incorrect package name

### DIFF
--- a/src/pages/metapackages/open-source/index.md
+++ b/src/pages/metapackages/open-source/index.md
@@ -82,11 +82,11 @@ To improve the developer experience even further, you can add these configuratio
     },
     ```
 
-1. Require in `magento/magento2-pwa` extension by adding the following to the `composer.json` file of your cloud instances.
+1. Require the `magento/pwa` extension by adding the following to the `composer.json` file of your cloud instances.
 
     ```json
     "require": {
-        "magento/magento2-pwa": "0.2.1"
+        "magento/pwa": "0.2.1"
     },
     ```
 

--- a/src/pages/tutorials/setup-storefront/file-structure/index.md
+++ b/src/pages/tutorials/setup-storefront/file-structure/index.md
@@ -58,7 +58,7 @@ Edit the entry in the `browser` section of the `package.json` file if you want t
 
 For more information about Venia's drivers and adapters pattern, see: [Modular components][]
 
-[modular components]: /guides/packages/venia/drivers-adapters/
+[modular components]: /guides/packages/venia/driver-adapter/
 
 ### `index.js`
 

--- a/src/pages/tutorials/setup-storefront/file-structure/index.md
+++ b/src/pages/tutorials/setup-storefront/file-structure/index.md
@@ -58,7 +58,7 @@ Edit the entry in the `browser` section of the `package.json` file if you want t
 
 For more information about Venia's drivers and adapters pattern, see: [Modular components][]
 
-[modular components]: /guides/packages/venia/driver-adapter/
+[Modular components]: /guides/packages/venia/driver-adapter/
 
 ### `index.js`
 


### PR DESCRIPTION
## Description

Link missing a couple folders in the path.

## Affected Pages

https://developer.adobe.com/commerce/pwa-studio/guides/packages/venia/driver-adapter/

## Issue/Ticket Number

Fixes #132
Fixes #123