### PR TITLE
Removed old analytics link

### DIFF
--- a/src/pages/integrations/index.md
+++ b/src/pages/integrations/index.md
@@ -16,12 +16,6 @@ Add Page Builder content to your storefront.
 
 <DiscoverBlock width="45%" slots="link, text"/>
 
-[Adobe Analytics](analytics/)
-
-Add Adobe Analytics to your PWA instance.
-
-<DiscoverBlock width="45%" slots="link, text"/>
-
 [Adobe Commerce](adobe-commerce/)
 
 Make the most of your Adobe Commerce instance.


### PR DESCRIPTION
## Description

This PR removes a link to old analytics topics, which as been superceded by Experience Platform info.

## Affected Pages

https://developer.adobe.com/commerce/pwa-studio/integrations/