### PR TITLE
Replace obsolete devdocs links

### DIFF
--- a/src/pages/api/peregrine/targets/index.md
+++ b/src/pages/api/peregrine/targets/index.md
@@ -28,7 +28,7 @@ You can extend the functionality of Peregrine's custom hooks and talons by apply
 The `talon.wrapWith(module)` method is simlar to the [interceptor pattern][] used in Magento backend plugins.
 Peregrine will dynamically inject the code from the passed `module` "around" the implementation of a talon, by passing the talon function through the wrapper function before exporting it.
 
-[interceptor pattern]: https://devdocs.magento.com/guides/v2.4/extension-dev-guide/plugins.html
+[interceptor pattern]: https://developer.adobe.com/commerce/php/development/components/plugins/
 
 See the [Modify talon results][] tutorial for step-by-step instructions on working with wrapper modules.
 

--- a/src/pages/guides/general-concepts/internationalization/index.md
+++ b/src/pages/guides/general-concepts/internationalization/index.md
@@ -15,7 +15,7 @@ The language packages themselves are extensions the application installs using C
 
 For more information, see the core documentation topic: [Translations overview][].
 
-[translations overview]: https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/translations/xlate.html
+[translations overview]: https://developer.adobe.com/commerce/frontend-core/guide/translations/
 
 The tight coupling between each applications' i18n feature and the frontend theme makes it difficult to use the same translation mechanisms in PWA Studio storefronts.
 Instead, PWA Studio provides its own i18n feature that follows a similar design as the one in Adobe Commerce and Magento Open Source.

--- a/src/pages/guides/storefront-architecture/index.md
+++ b/src/pages/guides/storefront-architecture/index.md
@@ -29,7 +29,7 @@ This is known as **service isolation**.
 Adobe Commerce and Magento Open Source services, such as those for customers, product catalog, and checkout, provide an API through [service contracts][].
 PWA Studio storefronts interact with these services through [GraphQL][] and REST services.
 
-[service contracts]: https://devdocs.magento.com/guides/v2.3/extension-dev-guide/service-contracts/service-contracts.html
+[service contracts]: https://developer.adobe.com/commerce/php/development/components/service-contracts/
 [graphql]: https://github.com/magento/graphql-ce
 
 For more information about service isolation, see: [Service Isolation Vision][].

--- a/src/pages/guides/storefront-architecture/run-time/index.md
+++ b/src/pages/guides/storefront-architecture/run-time/index.md
@@ -20,7 +20,7 @@ Those external API services communicate with the backend application's internal 
 until full coverage is complete, developers can use the [**REST API**][] to fill in existing coverage gaps.
 
 [graphql api]: https://devdocs.magento.com/guides/v2.3/graphql/
-[**rest api**]: https://devdocs.magento.com/guides/v2.3/rest/bk-rest.html
+[**rest api**]: https://developer.adobe.com/commerce/webapi/rest/
 
 To make secure, admin-authorized calls, configure the storefront's [UPWARD][] server to make the request using REST or RPC.
 

--- a/src/pages/integrations/adobe-commerce/theme-vs-storefront/index.md
+++ b/src/pages/integrations/adobe-commerce/theme-vs-storefront/index.md
@@ -15,7 +15,7 @@ This topic compares the traditional theme development approach of Adobe Commerce
 An Adobe Commerce or Magento Open Source theme is a type of [component][] that defines how a store looks.
 It is deeply integrated with the application and depends on the core code for functionality.
 
-[component]: https://devdocs.magento.com/guides/v2.1/extension-dev-guide/bk-extension-dev-guide.html
+[component]: https://developer.adobe.com/commerce/php/development/
 
 A theme is always built on top of an existing parent theme.
 Out of the box, the Adobe Commerce and Magento Open Source applications provide the **Blank** and **Luma** themes that developers extend or customize to create custom storefronts.
@@ -26,7 +26,7 @@ Every other theme builds on, overrides, or customizes these files.
 
 For more information on themes, see the [Frontend Developer Guide][] for the core application.
 
-[frontend developer guide]: https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/bk-frontend-dev-guide.html
+[frontend developer guide]: https://developer.adobe.com/commerce/frontend-core/guide/
 
 ### PWA Studio storefront application
 
@@ -57,7 +57,7 @@ each approach uses a different definition of this term.
 In theme development, _components_ mostly refers to [Adobe's UI Components][].
 These components are standard UI elements, such as tables, buttons, and dialogs, that Adobe provides to make theme development easier.
 
-[adobe's ui components]: https://devdocs.magento.com/guides/v2.3/ui_comp_guide/bk-ui_comps.html
+[adobe's ui components]: https://developer.adobe.com/commerce/frontend-core/ui-components/
 
 In PWA Studio, _components_ refers to [React][] components.
 React components are modular pieces that make up a React application, such as a PWA storefront.
@@ -120,10 +120,10 @@ The following table is a summary of general skills needed for theme development:
 
 [jquery]: https://jquery.com/
 [knockoutjs]: https://knockoutjs.com/
-[css]: https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css-overview.html
+[css]: https://developer.adobe.com/commerce/frontend-core/guide/css/
 [less]: http://lesscss.org/
-[theme layouts]: https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/layout-overview.html
-[theme templates]: https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/templates/template-overview.html
+[theme layouts]: https://developer.adobe.com/commerce/frontend-core/guide/layouts/
+[theme templates]: https://developer.adobe.com/commerce/frontend-core/guide/templates/
 [theme ui library]: https://magento-devdocs.github.io/magento2-ui-library/
 
 ### PWA storefront developers

--- a/src/pages/integrations/product-recommendations/index.md
+++ b/src/pages/integrations/product-recommendations/index.md
@@ -36,7 +36,7 @@ The `venia-product-recommendations` package requires [PWA Studio 10.0.0](https:/
    Other recommendation types use catalog data only and do not use any behavioral data.
    See the [user guide](https://docs.magento.com/user-guide/marketing/product-recommendations.html#trainmlmodels) to learn how Adobe Sensei trains machine learning models that results in higher quality recommendations.
 
-1. The backend functionality is provided by the [Product Recommendations module for Adobe Commerce](https://devdocs.magento.com/recommendations/install-configure.html).
+1. The backend functionality is provided by the [Product Recommendations module for Adobe Commerce](https://experienceleague.adobe.com/docs/commerce-merchant-services/product-recommendations/getting-started/install-configure.html).
 
 1. Additionally, you need to install the `module-data-services-graphql` module that expands the application's existing GraphQL coverage to include fields required for storefront behavioral data collection.
 

--- a/src/pages/metapackages/commerce/index.md
+++ b/src/pages/metapackages/commerce/index.md
@@ -47,7 +47,7 @@ At this point, you should see symlinks for all the `pwa-commerce` modules inside
 -  Run a Magento installation with additional modules.
 -  Develop locally using the standard git workflow.
 
-You may need to ensure that there are no `Magento_PWA*` modules listed as `enabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/enable-module.html).
+You may need to ensure that there are no `Magento_PWA*` modules listed as `enabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
 
 ## Setting up the Git workflow
 

--- a/src/pages/metapackages/open-source/index.md
+++ b/src/pages/metapackages/open-source/index.md
@@ -45,7 +45,7 @@ At this point, you should see symlinks for all the `pwa` modules inside the `ven
 -  Run a Magento installation with additional modules.
 -  Develop locally using the standard git workflow.
 
-You may need to ensure that there are no `Magento_PWA*` modules listed as `enabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/enable-module.html).
+You may need to ensure that there are no `Magento_PWA*` modules listed as `enabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
 
 ## Setting up the Git workflow
 

--- a/src/pages/metapackages/venia-sample-data/index.md
+++ b/src/pages/metapackages/venia-sample-data/index.md
@@ -47,4 +47,4 @@ This metapackage contains Venia Sample Data modules you can install to help you 
 
 At this point, the venia-sample-data metapackage modules are symlinked within your vendor directory, which allows you to run the with additional modules and do development using git.
 
-When you run bin/magento module: status, make sure there are no Magento Venia Sample Data modules listed as disabled. If they are, [follow the instructions on how to enable them](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/enable-module.html).
+When you run bin/magento module: status, make sure there are no Magento Venia Sample Data modules listed as disabled. If they are, [follow the instructions on how to enable them](https://developer.adobe.com/commerce/php/development/build/component-management/).

--- a/src/pages/tutorials/targets/modify-talon-results/index.md
+++ b/src/pages/tutorials/targets/modify-talon-results/index.md
@@ -18,7 +18,7 @@ In core Adobe Commerce and Magento Open Source development:
 
 See: [Plugins (Interceptors)][]
 
-[plugins (interceptors)]: https://devdocs.magento.com/guides/v2.4/extension-dev-guide/plugins.html
+[plugins (interceptors)]: https://developer.adobe.com/commerce/php/development/components/plugins/
 
 PWA Studio's extensibility framework provides a similar feature that allows you to intercept a talon call and surround it with custom logic.
 This is useful if you want to add tracking logic or alter the incoming or outgoing values for a talon.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces links to `https://devdocs.magento.com` topics that have already been migrated to the Adobe Devsite (`https://developer.adobe.com`).

## Affected pages

- See changed files

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My changes follow the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
