### PR TITLE
Update navigation header

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,17 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-const { versions, pages, subPages } = require("./src/data/navigation");
+const { pages, subPages } = require("./src/data/navigation");
 
 module.exports = {
   siteMetadata: {
-    versions: versions,
+    "home": {
+      "title": "Commerce",
+      "path": "/commerce/docs"
+    },
     pages: pages,
     subPages: subPages,
   },
-  pathPrefix: process.env.PATH_PREFIX || "/commerce/pwa-studio/",
-  flags: {
-    DEV_SSR: false
-  },
   plugins: [`@adobe/gatsby-theme-aio`],
+  pathPrefix: process.env.PATH_PREFIX || '/commerce/pwa-studio/'
 };


### PR DESCRIPTION
## Description

This PR updates the navigation header by replacing the "Products" link with a link to our Commerce devdocs index page, named "Commerce."

## Related Issue

COMDOX-340

## Motivation and Context

The default "Products" header link is not useful for users of Commerce docs. Instead, we needed a link to the Commerce Developer docs main/index page.

## How Has This Been Tested?

Tested locally using by running yarn start:prefix and replacing localhost:9000/commerce/docs/ with https://developer.adobe.com/commerce/docs/ to ensure the new link is working. 

## Screenshots:

**Old navigation header was similar to this but with the appropriate docs site name:**

<img width="942" alt="image" src="https://user-images.githubusercontent.com/1828494/208771220-f1ef37fe-efdc-4d58-bd09-ceeadd60ff42.png">

**New navigation header replaces Products with the Commerce link:**

<img width="836" alt="image" src="https://user-images.githubusercontent.com/1828494/208771309-1595a486-6c10-41bb-8e25-1ebbacf93f68.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed."