### PR TITLE
fix: update PWA's coverage of Adobe Commerce features

### DIFF
--- a/src/pages/integrations/adobe-commerce/features/images/api.svg
+++ b/src/pages/integrations/adobe-commerce/features/images/api.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="17px" height="17px" viewBox="0 0 17 17" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>api-only</title>
+    <g id="api-only" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="api" transform="translate(0.026451, 0.000000)" fill="#6E6E6E" fill-rule="nonzero">
+            <polygon id="Line-2" points="12 9 17 13 12 17 12 14 0 14 0 12 12 12"></polygon>
+            <polygon id="Line-2" transform="translate(8.500000, 4.000000) scale(-1, 1) translate(-8.500000, -4.000000) " points="12 0 17 4 12 8 12 5 -5.68434189e-14 5 -5.68434189e-14 3 12 3"></polygon>
+        </g>
+    </g>
+</svg>

--- a/src/pages/integrations/adobe-commerce/features/index.css
+++ b/src/pages/integrations/adobe-commerce/features/index.css
@@ -3,7 +3,7 @@ div.main {
   justify-content: left;
   display: flex;
   flex-direction: column;
-  margin: 0 10px 0 10px;
+  margin: 0 10px 60px 10px;
   width: auto;
   min-width: 320px;
   max-width: 800px;
@@ -101,7 +101,7 @@ tbody tr.category-feature:last-child td {
 /*** Cells ***/
 
 .category-feature td {
-  padding: 7px 0px 0px 10px;
+  padding: 7px 7px 0px 10px;
 }
 
 .category-feature td:nth-child(2) {
@@ -132,36 +132,27 @@ tbody tr.category-feature:last-child td {
   display: inline-block;
   content: " ";
   background-image: url("./images/full.svg");
-  background-size: 18px 18px;
-  height: 18px;
-  width: 18px;
+  background-size: 16px 16px;
+  height: 16px;
+  width: 16px;
 }
 
 .support.Partial::before {
   display: inline-block;
   content: " ";
   background-image: url("./images/partial.svg");
-  background-size: 18px 18px;
-  height: 18px;
-  width: 18px;
+  background-size: 16px 16px;
+  height: 16px;
+  width: 16px;
 }
 
-.support.Planned::before {
+.support.API::before {
   display: inline-block;
   content: " ";
-  background-image: url("./images/planned.svg");
-  background-size: 18px 18px;
-  height: 18px;
-  width: 18px;
-}
-
-.support.Custom::before {
-  display: inline-block;
-  content: " ";
-  background-image: url("./images/custom.svg");
-  background-size: 18px 18px;
-  height: 18px;
-  width: 18px;
+  background-image: url("./images/api.svg");
+  background-size: 16px 16px;
+  height: 16px;
+  width: 16px;
 }
 
 .legend-keys {
@@ -169,7 +160,7 @@ tbody tr.category-feature:last-child td {
   flex-direction: column;
   justify-content: flex-start;
   align-items: left;
-  margin: 0 10px 20px 0;
+  margin: 0 10px 20px 10px;
   font-size: 16px;
 }
 
@@ -212,21 +203,10 @@ tbody tr.category-feature:last-child td {
   margin-bottom: -2px;
 }
 
-.legend.Planned::before {
+.legend.API::before {
   display: inline-block;
   content: " ";
-  background-image: url("./images/planned.svg");
-  background-size: 14px 14px;
-  height: 14px;
-  width: 14px;
-  margin-left: 5px;
-  margin-bottom: -2px;
-}
-
-.legend.Custom::before {
-  display: inline-block;
-  content: " ";
-  background-image: url("./images/custom.svg");
+  background-image: url("./images/api.svg");
   background-size: 14px 14px;
   height: 14px;
   width: 14px;

--- a/src/pages/integrations/adobe-commerce/features/index.js
+++ b/src/pages/integrations/adobe-commerce/features/index.js
@@ -8,13 +8,12 @@ export default function Component() {
       <div class="main">
         <h1 class="spectrum-Heading spectrum-Heading--sizeXL spectrum-Heading--light hackP">Commerce coverage</h1>
 
-        <p class="hackP">PWA Studio’s storefront app — Venia — provides the following out-of-the-box coverage for Adobe Commerce and Magento Open Source features. The icons show the current and planned coverage of each Commerce feature. Features that are not implemented — and not yet on our roadmap — show that custom implementation is required.</p>
+        <p class="hackP">PWA Studio's storefront app — Venia — provides the following out-of-the-box coverage for Adobe Commerce and Open Source features. The icons show the coverage of each Commerce feature.</p>
 
         <div class="legend-keys">
           <div class="legend Full"> — Full support</div>
           <div class="legend Partial"> — Partial support</div>
-          <div class="legend Planned"> — Planned support</div>
-          <div class="legend Custom"> — Customization required</div>
+          <div class="legend API"> — API support only</div>
           <div class="legend Commerce"> — Commerce-only</div>
         </div>
 
@@ -46,8 +45,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>B2B <span class="support Commerce"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -125,8 +124,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Product with Custom options <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -134,8 +133,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Grouped <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -143,8 +142,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Bundled <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -152,8 +151,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Downloadable <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -223,8 +222,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>CMS Widgets <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Custom support">
-                  <span class="support Custom"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -292,10 +291,19 @@ export default function Component() {
             </tr>
 
             <tr class="category-feature">
-              <td>Staging &amp; Preview <span class="support Commerce"></span></td>
+              <td>Staging<span class="support Commerce"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="Full support">
+                  <span class="support Full"></span>
+                </span>
+              </td>
+            </tr>
+
+            <tr class="category-feature">
+              <td>Preview<span class="support Commerce"></span></td>
+              <td>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -303,8 +311,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Related Products <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -321,8 +329,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Reward Points <span class="support Commerce"></span></td>
               <td>
-                <span class="tooltip left" data-text="Custom support">
-                  <span class="support Custom"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -383,8 +391,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Reviews <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Custom support">
-                  <span class="support Custom"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -392,8 +400,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Add To Compare <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Custom support">
-                  <span class="support Custom"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -525,8 +533,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Items Per Page <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Custom support">
-                  <span class="support Custom"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -720,8 +728,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Backorders <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -729,8 +737,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Advanced Inventory <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -782,8 +790,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Stores on separate domains <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -871,8 +879,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Re-order <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -880,8 +888,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Returns <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Planned support">
-                  <span class="support Planned"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -889,8 +897,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Store Credit <span class="support Commerce"></span></td>
               <td>
-                <span class="tooltip left" data-text="Custom support">
-                  <span class="support Custom"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -898,8 +906,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Gift Registry <span class="support Commerce"></span></td>
               <td>
-                <span class="tooltip left" data-text="Custom support">
-                  <span class="support Custom"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -907,8 +915,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Product Reviews <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Custom support">
-                  <span class="support Custom"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -916,8 +924,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Invitations <span class="support Commerce"></span></td>
               <td>
-                <span class="tooltip left" data-text="Custom support">
-                  <span class="support Custom"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>
@@ -925,8 +933,8 @@ export default function Component() {
             <tr class="category-feature">
               <td>Dashboard <span class="support OpenSource"></span></td>
               <td>
-                <span class="tooltip left" data-text="Custom support">
-                  <span class="support Custom"></span>
+                <span class="tooltip left" data-text="API support only">
+                  <span class="support API"></span>
                 </span>
               </td>
             </tr>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates PWA's coverage of Adobe Commerce features as instructed by Olena from an email with  attached images.

**Email Instructions:**

Hi Bruce and Jeff,
Could you update the [PWA Studio feature coverage ](https://developer.adobe.com/commerce/pwa-studio/integrations/adobe-commerce/features/). As we are not developing new features, it is misleading and confusing.
I’m attaching the summary of the changes; but in a nutshell, we combine “customization required” and “plan to support” in one "[API support only]"—original text was missing. 


## Affected pages

- [Commerce coverage](https://developer.adobe.com/commerce/pwa-studio/integrations/adobe-commerce/features/)


![pwa-coverage-updates-1](https://user-images.githubusercontent.com/1828494/236587747-150bce94-b4d3-450c-bee2-d6293d376e19.png)
![pwa-coverage-updates-2](https://user-images.githubusercontent.com/1828494/236587748-d299d97e-c182-4c70-a580-86207335f23c.png)
![pwa-coverage-updates-3](https://user-images.githubusercontent.com/1828494/236587749-b830a975-804c-4d0e-ab4b-e94a703691af.png)
