### PR TITLE
Removing note about EPC release timeline.

### DIFF
--- a/src/pages/integrations/adobe-commerce/aep/index.md
+++ b/src/pages/integrations/adobe-commerce/aep/index.md
@@ -4,8 +4,6 @@ title: Adobe Experience Platform
 
 # Adobe Experience Platform
 
-**NOTE**: The Experience Platform Connector for Adobe Commerce is scheduled for released in the second half of 2022. PWA Studio is publishing this code in anticipation of the Experience Platform Connector release.
-
 Included in the PWA Studio 12.5.0 release is an eventing framework that lets store owners install extensions that track user interaction within their site and collect analytics information.
 With the Experience Platform Connector extension, Adobe Commerce users with an Adobe Experience Platform (AEP) subscription can get event data from PWA Studio storefronts and process it on the AEP.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the note about when the Experience Platform Connector will release.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/pwa-studio/integrations/adobe-commerce/aep/

