### PR TITLE
Update index.md

### DIFF
--- a/src/pages/metapackages/commerce/index.md
+++ b/src/pages/metapackages/commerce/index.md
@@ -52,17 +52,23 @@ At this point, you should see symlinks for all the `pwa-commerce` modules inside
 -  Run a Magento installation with additional modules.
 -  Develop locally using the standard git workflow.
 
-You may need to ensure that there are no `Magento_*Pwa` modules listed as `disabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
+Please enure all of the required modules are enabled when you run `bin/magento module:status`. For assistance on how to do that, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
 
 Note: You should expect to see the following modules
 
-    Magento_ContactGraphQlPwa
-    Magento_NewsletterGraphQlPwa
-    Magento_PageBuilderPwa
-    Magento_ReCaptchaGraphQlPwa
-    Magento_ReCaptchaPwa
-    Magento_UrlRewriteGraphQlPwa
-    *REVIEWER* I only have access to run the open source one, do we want to update this too? 
+```terminal
+Magento_BannerGraphQlAux
+Magento_EavGraphQlAux
+Magento_CatalogGraphQlAux
+Magento_SalesGraphQlAux
+Magento_WeeeGraphQlAux
+Magento_ContactGraphQlPwa
+Magento_NewsletterGraphQlPwa
+Magento_PageBuilderPwa
+Magento_ReCaptchaGraphQlPwa
+Magento_ReCaptchaPwa
+Magento_UrlRewriteGraphQlPwa
+```
 
 At this point, you should see that all the PWA modules are now enabled.
 

--- a/src/pages/metapackages/commerce/index.md
+++ b/src/pages/metapackages/commerce/index.md
@@ -52,7 +52,19 @@ At this point, you should see symlinks for all the `pwa-commerce` modules inside
 -  Run a Magento installation with additional modules.
 -  Develop locally using the standard git workflow.
 
-You may need to ensure that there are no `Magento_PWA*` modules listed as `enabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
+You may need to ensure that there are no `Magento_*Pwa` modules listed as `disabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
+
+Note: You should expect to see the following modules
+
+    Magento_ContactGraphQlPwa
+    Magento_NewsletterGraphQlPwa
+    Magento_PageBuilderPwa
+    Magento_ReCaptchaGraphQlPwa
+    Magento_ReCaptchaPwa
+    Magento_UrlRewriteGraphQlPwa
+    *REVIEWER* I only have access to run the open source one, do we want to update this too? 
+
+At this point, you should see that all the PWA modules are now enabled.
 
 ## Setting up the Git workflow
 

--- a/src/pages/metapackages/commerce/index.md
+++ b/src/pages/metapackages/commerce/index.md
@@ -54,7 +54,7 @@ At this point, you should see symlinks for all the `pwa-commerce` modules inside
 
 Please enure all of the required modules are enabled when you run `bin/magento module:status`. For assistance on how to do that, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
 
-Note: You should expect to see the following modules
+The following modules should now be enabled:
 
 ```terminal
 Magento_BannerGraphQlAux
@@ -69,8 +69,6 @@ Magento_ReCaptchaGraphQlPwa
 Magento_ReCaptchaPwa
 Magento_UrlRewriteGraphQlPwa
 ```
-
-At this point, you should see that all the PWA modules are now enabled.
 
 ## Setting up the Git workflow
 

--- a/src/pages/metapackages/commerce/index.md
+++ b/src/pages/metapackages/commerce/index.md
@@ -52,8 +52,7 @@ At this point, you should see symlinks for all the `pwa-commerce` modules inside
 -  Run a Magento installation with additional modules.
 -  Develop locally using the standard git workflow.
 
-Please enure all of the required modules are enabled when you run `bin/magento module:status`. For assistance on how to do that, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
-
+Make sure that all of the required modules are enabled when you run `bin/magento module:status`. See, [Enable or disable a component](https://developer.adobe.com/commerce/php/development/build/component-management/) in the _PHP Developer Guide_ for instructions.
 The following modules should now be enabled:
 
 ```terminal

--- a/src/pages/metapackages/open-source/index.md
+++ b/src/pages/metapackages/open-source/index.md
@@ -50,7 +50,15 @@ At this point, you should see symlinks for all the `pwa` modules inside the `ven
 -  Run a Magento installation with additional modules.
 -  Develop locally using the standard git workflow.
 
-You may need to ensure that there are no `Magento_PWA*` modules listed as `enabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
+You may need to ensure that there are no `Magento_*Pwa` modules listed as `enabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
+
+2. Enable the PWA modules
+    ```bash
+    bin/magento module:enable --clear-static-content Magento_ContactGraphQlPwa
+    bin/magento module:enable --clear-static-content Magento_NewsletterGraphQlPwa
+    *REVIEWER* insert other modules here or generalise    
+    ```
+At this point, you should see that all the PWA modules are now enabled
 
 ## Setting up the Git workflow
 

--- a/src/pages/metapackages/open-source/index.md
+++ b/src/pages/metapackages/open-source/index.md
@@ -50,8 +50,7 @@ At this point, you should see symlinks for all the `pwa` modules inside the `ven
 -  Run a Magento installation with additional modules.
 -  Develop locally using the standard git workflow.
 
-Please enure all of the required modules are enabled when you run `bin/magento module:status`. For assistance on how to do that, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
-
+Make sure that all of the required modules are enabled when you run `bin/magento module:status`. See, [Enable or disable a component](https://developer.adobe.com/commerce/php/development/build/component-management/) in the _PHP Developer Guide_ for instructions.
 The following modules should now be enabled:
 
 ```terminal

--- a/src/pages/metapackages/open-source/index.md
+++ b/src/pages/metapackages/open-source/index.md
@@ -52,7 +52,7 @@ At this point, you should see symlinks for all the `pwa` modules inside the `ven
 
 Please enure all of the required modules are enabled when you run `bin/magento module:status`. For assistance on how to do that, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
 
-Note: You should expect to see the following modules
+The following modules should now be enabled:
 
 ```terminal
 Magento_EavGraphQlAux
@@ -66,8 +66,6 @@ Magento_ReCaptchaGraphQlPwa
 Magento_ReCaptchaPwa
 Magento_UrlRewriteGraphQlPwa
 ```
-
-At this point, you should see that all the PWA modules are now enabled.
 
 ## Setting up the Git workflow
 

--- a/src/pages/metapackages/open-source/index.md
+++ b/src/pages/metapackages/open-source/index.md
@@ -50,15 +50,18 @@ At this point, you should see symlinks for all the `pwa` modules inside the `ven
 -  Run a Magento installation with additional modules.
 -  Develop locally using the standard git workflow.
 
-You may need to ensure that there are no `Magento_*Pwa` modules listed as `enabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
+You may need to ensure that there are no `Magento_*Pwa` modules listed as `disabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
 
-2. Enable the PWA modules
-    ```bash
-    bin/magento module:enable --clear-static-content Magento_ContactGraphQlPwa
-    bin/magento module:enable --clear-static-content Magento_NewsletterGraphQlPwa
-    *REVIEWER* insert other modules here or generalise    
-    ```
-At this point, you should see that all the PWA modules are now enabled
+Note: You should expect to see the following modules
+
+    Magento_ContactGraphQlPwa
+    Magento_NewsletterGraphQlPwa
+    Magento_PageBuilderPwa
+    Magento_ReCaptchaGraphQlPwa
+    Magento_ReCaptchaPwa
+    Magento_UrlRewriteGraphQlPwa
+
+At this point, you should see that all the PWA modules are now enabled.
 
 ## Setting up the Git workflow
 

--- a/src/pages/metapackages/open-source/index.md
+++ b/src/pages/metapackages/open-source/index.md
@@ -50,16 +50,22 @@ At this point, you should see symlinks for all the `pwa` modules inside the `ven
 -  Run a Magento installation with additional modules.
 -  Develop locally using the standard git workflow.
 
-You may need to ensure that there are no `Magento_*Pwa` modules listed as `disabled` when you run `bin/magento module:status`. If there are, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
+Please enure all of the required modules are enabled when you run `bin/magento module:status`. For assistance on how to do that, [follow the docs on how to enable modules](https://developer.adobe.com/commerce/php/development/build/component-management/).
 
 Note: You should expect to see the following modules
 
-    Magento_ContactGraphQlPwa
-    Magento_NewsletterGraphQlPwa
-    Magento_PageBuilderPwa
-    Magento_ReCaptchaGraphQlPwa
-    Magento_ReCaptchaPwa
-    Magento_UrlRewriteGraphQlPwa
+```terminal
+Magento_EavGraphQlAux
+Magento_CatalogGraphQlAux
+Magento_SalesGraphQlAux
+Magento_WeeeGraphQlAux
+Magento_ContactGraphQlPwa
+Magento_NewsletterGraphQlPwa
+Magento_PageBuilderPwa
+Magento_ReCaptchaGraphQlPwa
+Magento_ReCaptchaPwa
+Magento_UrlRewriteGraphQlPwa
+```
 
 At this point, you should see that all the PWA modules are now enabled.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds Module Enable step for PWA modules. Corrected search syntax for Magento_*Pwa modules.

PWA Studio looks to work ootb when also building the M2 backend, but in my use case, I have an existing M2 backend and it's been a little tricky getting things working. One reason is because my backend didn't have these PWA modules installed (or enabled) and I wanted to clear it up in the docs. Ideally the PWA docs would also make it clear that if using an existing backend, some additional modules are required

## Affected pages

- https://developer.adobe.com/commerce/pwa-studio/metapackages/open-source/