### PR TITLE
Update module name

### DIFF
--- a/src/pages/integrations/adobe-commerce/aep/index.md
+++ b/src/pages/integrations/adobe-commerce/aep/index.md
@@ -31,7 +31,7 @@ Use your storefront project's package manager(`node` or `yarn`), to install the 
 For example, if your project uses `yarn` run the following command:
 
 ```terminal
-yarn add @magento/data-connection
+yarn add @magento/experience-platform-connector
 ```
 
 ## Adobe Commerce backend configuration


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changes the module name back to `experience-platform-connector`. While the feature name changed, the actual module name did not.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/pwa-studio/integrations/adobe-commerce/aep/

