### PR TITLE
Changes to make the tutorial work with the PWA 14 version

### DIFF
--- a/src/pages/tutorials/targets/modify-talon-results/index.md
+++ b/src/pages/tutorials/targets/modify-talon-results/index.md
@@ -115,7 +115,7 @@ module.exports = (targets) => {
   // Set the buildpack features required by this extension
   const builtins = targets.of("@magento/pwa-buildpack");
   builtins.specialFeatures.tap((featuresByModule) => {
-    featuresByModule["@my-extension/my-product-page"] = {
+    featuresByModule["my-extension"] = {
       // Wrapper modules must be ES Modules
       esModules: true,
     };
@@ -139,7 +139,7 @@ Inside the `useProductCategoriesList.js` file, add the following content:
 
 ```js
 import { useMemo } from "react";
-import { useQuery } from "@apollo/react-hooks";
+import { useQuery } from "@apollo/client";
 import gql from "graphql-tag";
 
 const GET_PRODUCT_CATEGORIES = gql`


### PR DESCRIPTION
Fixing errors:
- Can't resolve '@my-extension/my-product-page'
- Can't resolve@apollo/react-hooks 

There will be an other error:
Missing field 'uid' while extracting keyFields from {"name":"Tops","url_path":"women/tops-women","__typename":"CategoryTree"}

But at least the console log data is displayed.

## Purpose of this pull request

This pull request (PR) actualizes the tutorial for the PWA 14 version.

## Affected pages

- https://developer.adobe.com/commerce/pwa-studio/tutorials/targets/modify-talon-results/#test-on-a-local-instance

