### PR TITLE
fix: broken internal link

### DIFF
--- a/src/pages/guides/general-concepts/client-side-caching/index.md
+++ b/src/pages/guides/general-concepts/client-side-caching/index.md
@@ -98,7 +98,7 @@ If an image does not have a width parameter, a cached image with the same name b
 The Venia implementation storefront uses the Apollo GraphQL client to make requests to the Adobe Commerce or Magento Open Source GraphQL endpoint.
 It also incorporates the default [InMemoryCache][] implementation to add caching abilities to the client.
 
-[inmemorycache]: https://www.apollographql.com/docs/react/advanced/caching
+[inmemorycache]: https://www.apollographql.com/docs/react/api/cache/InMemoryCache
 
 The cache is persisted between browser sessions in `window.localstorage` using the [apollo-cache-persist][] module.
 This lets the Apollo client maintain its cached data even when the user closes the application.

--- a/src/pages/integrations/product-recommendations/index.md
+++ b/src/pages/integrations/product-recommendations/index.md
@@ -94,4 +94,4 @@ const { data, error, isLoading } = useRecsData({ pageType: Pagetypes.CMS });
 ```
 
 [venia-product-recommendations]: /guides/#custom-react-hooks-and-component
-[extensibility framework]: /general-concepts/extensibility/#intercept-files
+[extensibility framework]: /guides/general-concepts/extensibility/#intercept-files


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a broken internal link and a broken external link.

I don't think that the link validation works on internal link definitions. Generally, in-line links are better than link definitions for internal link because link definitions often behave unexpectedly.

## Affected pages

- https://developer.adobe.com/commerce/pwa-studio/integrations/product-recommendations/#render-recommendations
