### PR TITLE
Replace links to decommissioned sources

### DIFF
--- a/src/data/auto-generated/peregrine/lib/talons/CartPage/ProductListing/useProductListing.md
+++ b/src/data/auto-generated/peregrine/lib/talons/CartPage/ProductListing/useProductListing.md
@@ -287,7 +287,7 @@ It provides props data for rendering an edit modal component.
 | Name | Type | Description |
 | --- | --- | --- |
 | setVariantPrice | `function` | Function for setting a product's variant price. |
-| variantPrice | `Object` | The variant price for a product. See [Money object](https://devdocs.magento.com/guides/v2.4/graphql/product/product-interface.html#Money). |
+| variantPrice | `Object` | The variant price for a product. See [Money object](https://developer.adobe.com/commerce/webapi/graphql/product/product-interface.html#Money). |
 
 Object type returned by the [useProductForm](useProductForm) talon.
 It provides props data for a product form UI component inside a modal.

--- a/src/pages/guides/storefront-architecture/run-time/index.md
+++ b/src/pages/guides/storefront-architecture/run-time/index.md
@@ -20,7 +20,7 @@ Those external API services communicate with the backend application's internal 
 [GraphQL API][] coverage increases with every Adobe Commerce and Magento Open Source release, but
 until full coverage is complete, developers can use the [**REST API**][] to fill in existing coverage gaps.
 
-[graphql api]: https://devdocs.magento.com/guides/v2.3/graphql/
+[graphql api]: https://developer.adobe.com/commerce/webapi/graphql/
 [**rest api**]: https://developer.adobe.com/commerce/webapi/rest/
 
 To make secure, admin-authorized calls, configure the storefront's [UPWARD][] server to make the request using REST or RPC.

--- a/src/pages/integrations/product-recommendations/index.md
+++ b/src/pages/integrations/product-recommendations/index.md
@@ -16,10 +16,10 @@ You can integrate Product Recommendations powered by [Adobe Sensei](https://www.
 
 ![Product Recommendations for PWA Studio](images/pwa-arch-diag-sensei.svg)
 
-Adobe's [Product Recommendations powered by Adobe Sensei](https://docs.magento.com/user-guide/marketing/product-recommendations.html) is a feature backed by several SaaS services.
+Adobe's [Product Recommendations powered by Adobe Sensei](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/product-recommendations/overview) is a feature backed by several SaaS services.
 The **Store** side includes your PWA storefront, which contains the event collector and recommendations layout template, and the backend, which includes the GraphQL endpoints, SaaS Export module, and the Admin UI.
 
-After you install the Product Recommendations PWA extension on your store, it will start sending [behavioral data](https://devdocs.magento.com/recommendations/events.html) to Adobe Sensei with no additional setup.
+After you install the Product Recommendations PWA extension on your store, it will start sending [behavioral data](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/product-recommendations/developer/events) to Adobe Sensei with no additional setup.
 Adobe Sensei processes this behavioral data along with the catalog data from the backend and calculates the product associations leveraged by the recommendations service.
 At this point, the merchant can create and manage recommendation units from the Adobe Commerce Admin UI then fetch those product recommendation units from their PWA storefront.
 
@@ -40,7 +40,7 @@ The `venia-product-recommendations` package requires [PWA Studio 10.0.0](https:/
    This package contains storefront functionality to collect required behavioral data and render the recommendations.
    Some recommendation types use behavioral data from your shoppers to train machine learning models that build personalized recommendations.
    Other recommendation types use catalog data only and do not use any behavioral data.
-   See the [user guide](https://docs.magento.com/user-guide/marketing/product-recommendations.html#trainmlmodels) to learn how Adobe Sensei trains machine learning models that results in higher quality recommendations.
+   See the [user guide](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/product-recommendations/overview#trainmlmodels) to learn how Adobe Sensei trains machine learning models that results in higher quality recommendations.
 
 1. The backend functionality is provided by the [Product Recommendations module for Adobe Commerce](https://experienceleague.adobe.com/docs/commerce-merchant-services/product-recommendations/getting-started/install-configure.html).
 
@@ -52,8 +52,8 @@ The `venia-product-recommendations` package requires [PWA Studio 10.0.0](https:/
 
 ## Create recommendation units
 
-Creating a product recommendation unit for your PWA storefront is the same as [creating one for a theme](https://docs.magento.com/user-guide/marketing/create-new-rec.html).
-When you create a recommendation unit in the Admin UI panel, you will need to place components that render product recommendations on appropriate storefront pages. You will do this only once per [supported page type](https://docs.magento.com/user-guide/marketing/product-recommendations.html#supportedrecs).
+Creating a product recommendation unit for your PWA storefront is the same as [creating one for a theme](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/product-recommendations/admin/create).
+When you create a recommendation unit in the Admin UI panel, you will need to place components that render product recommendations on appropriate storefront pages. You will do this only once per [supported page type](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/product-recommendations/overview#supportedrecs).
 
 ## Render recommendations
 

--- a/src/pages/tutorials/production-deployment/adobe-commerce/index.md
+++ b/src/pages/tutorials/production-deployment/adobe-commerce/index.md
@@ -11,7 +11,7 @@ keywords:
 [Adobe Commerce][] provides a managed and automated hosting platform for its commerce software in the Cloud.
 You can use this platform to host your storefront code by installing packages developed specifically to connect your storefront with Adobe Commerce software on the same server.
 
-[adobe commerce]: https://devdocs.magento.com/cloud/bk-cloud.html
+[adobe commerce]: https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/overview
 
 ## Overview
 
@@ -24,9 +24,9 @@ You can use this setup to update and deploy your storefront project in the Cloud
 Before you follow this tutorial, you should be familiar with Cloud's [Starter workflow][] or [Pro workflow][] depending on your plan.
 Make sure you complete the [Cloud onboarding tasks][] to avoid account or access issues.
 
-[starter workflow]: https://devdocs.magento.com/cloud/architecture/starter-develop-deploy-workflow.html
-[pro workflow]: https://devdocs.magento.com/cloud/architecture/pro-develop-deploy-workflow.html
-[cloud onboarding tasks]: https://devdocs.magento.com/cloud/onboarding/onboarding-tasks.html
+[starter workflow]: https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/architecture/starter-develop-deploy-workflow
+[pro workflow]: https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/architecture/pro-develop-deploy-workflow
+[cloud onboarding tasks]: https://experienceleague.adobe.com/en/docs/commerce-cloud-service/start/onboarding
 
 Verify that your Adobe Commerce instance is [compatible][] with the PWA Studio version you use in your storefront project.
 
@@ -39,12 +39,12 @@ This tutorial requires the following tools:
 - [Composer][]
 - Yarn or NPM (depends on your storefront project configuration)
 
-[adobe commerce cli]: https://devdocs.magento.com/cloud/reference/cli-ref-topic.html
+[adobe commerce cli]: https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/dev-tools/cloud-cli/cloud-cli-overview
 [composer]: https://getcomposer.org/
 
 If you need to do more advanced Cloud tasks, see the [Cloud technologies and requirements][] for the full list of tools you need to fully manage the rest of your Cloud project.
 
-[cloud technologies and requirements]: https://devdocs.magento.com/cloud/requirements/cloud-requirements.html
+[cloud technologies and requirements]: https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/develop/overview
 
 You also need an existing storefront project to do this tutorial.
 Follow the instructions on the [Project setup][] page to set up your storefront project using the scaffolding tool.
@@ -166,7 +166,7 @@ PWA Studio storefronts require you to set specific [environment variables][] in 
 
 To set your Cloud project's runtime variables, edit the [`.magento.app.yaml`][] file and add entries to the `variables.env` section.
 
-[`.magento.app.yaml`]: https://devdocs.magento.com/cloud/project/magento-env-yaml.html
+[`.magento.app.yaml`]: https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/configure/env/configure-env-yaml
 
 ```text
 variables:
@@ -207,7 +207,7 @@ In the previous example, `/app/pmu35riuj7btw_stg/` is the Adobe Commerce applica
 This value is different for each environment in your Cloud project, so you must configure each of your project environments with the path specific to each instance.
 To find the correct root directory path for an environment, [SSH][] into the remote server and use the `pwd` command to find the Magento application root directory.
 
-[ssh]: https://devdocs.magento.com/cloud/env/environments-ssh.html
+[ssh]: https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/develop/secure-connections
 
 ## Build your storefront application
 
@@ -262,7 +262,7 @@ After you push changes to your Cloud project, the remote build process runs and 
 The Cloud topic on how to [Deploy your store][] provides more details on the deployment process.
 It also includes instructions for merging environment branches, such as integration to staging or staging to production.
 
-[deploy your store]: https://devdocs.magento.com/cloud/live/stage-prod-live.html
+[deploy your store]: https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/develop/deploy/staging-production
 
 If your workflow involves merging environment branches,
 you must rebuild your application bundle with the correct environment variables before you push your changes to the Cloud service because


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces links to decommissioned resources with actual up-to-date links.

## Affected pages

- https://developer.adobe.com/commerce/pwa-studio/api/peregrine/talons/CartPage/ProductListing/
- https://developer.adobe.com/commerce/pwa-studio/guides/storefront-architecture/run-time/
- https://developer.adobe.com/commerce/pwa-studio/integrations/product-recommendations/
- https://developer.adobe.com/commerce/pwa-studio/tutorials/production-deployment/adobe-commerce/